### PR TITLE
Feature: Trigger cache flush on $flushCache push message

### DIFF
--- a/jest.config.json
+++ b/jest.config.json
@@ -1,3 +1,5 @@
 {
-  "testEnvironment": "node"
+  "testEnvironment": "node",
+  "clearMocks": true,
+  "restoreMocks": true
 }

--- a/lib/client.js
+++ b/lib/client.js
@@ -321,8 +321,26 @@ class Client extends EventEmitter {
     }
   }
 
+  /**
+   * Handles push messages from the server.
+   */
   onPush(response) {
-    if (response.$cached && this.cache) {
+    if (!this.cache) {
+      return;
+    }
+
+    if (!response) {
+      return;
+    }
+
+    if (response.$flushCache) {
+      // Flush the entire cache.
+      this.cache.flush();
+      return;
+    }
+
+    if (response.$cached) {
+      // Invalidate a single entry in the cache.
       if (this.params.debug) {
         console.log(`[swell-node] ${this.params.endClientId} onPush`, response.$cached);
       }

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -1,32 +1,24 @@
-const assert = require('chai').assert;
+const { assert } = require('chai');
 const sinon = require('sinon');
+
 const Client = require('./client');
 const Cache = require('./cache');
 const Connection = require('./connection');
 
 describe('Client', () => {
-  let serverConnectStub = sinon.stub(Connection.prototype, 'connect');
+  let serverConnectStub;
 
   beforeEach(() => {
-    serverConnectStub.reset();
-  });
-
-  afterAll(() => {
-    serverConnectStub.restore();
+    sinon.stub(Connection.prototype, 'connect');
   });
 
   describe('#constructor', () => {
-    let initStub = sinon.stub(Client.prototype, 'init');
-    let connectStub = sinon.stub(Client.prototype, 'connect');
+    let initStub; 
+    let connectStub;
 
     beforeEach(() => {
-      initStub.reset();
-      connectStub.reset();
-    });
-
-    afterAll(() => {
-      initStub.restore();
-      connectStub.restore();
+      initStub = sinon.stub(Client.prototype, 'init');
+      connectStub = sinon.stub(Client.prototype, 'connect');
     });
 
     it('construct without init', () => {

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -680,6 +680,73 @@ describe('Client', () => {
     });
   });
 
+  describe('#onPush', () => {
+    let client;
+
+    describe('when caching is enabled', () => {
+      beforeEach(() => {
+        client = new Client('id', 'key', { cache: true });
+        client.cache = new Cache('id');
+
+        client.cache.put(
+          '/foo',
+          {},
+          {
+            $data: 'fooData',
+            $collection: 'foo',
+            $cached: { foo: 1 },
+          },
+        );
+
+        client.cache.put(
+          '/bar',
+          {},
+          {
+            $data: 'barData',
+            $collection: 'bar',
+            $cached: { bar: 2 },
+          },
+        );
+
+        assert.deepEqual(client.cache.getVersions(), { foo: 1, bar: 2 });
+
+        assert.deepEqual(
+          client.cache.get('/foo', {}),
+          { $cached: true, $collection: 'foo', $data: 'fooData' },
+        );
+        assert.deepEqual(
+          client.cache.get('/bar', {}),
+          { $cached: true, $collection: 'bar', $data: 'barData' },
+        );
+      });
+
+      it('flushes the cache', () => {
+        client.onPush({ $flushCache: true });
+
+        // Nothing should be cached.
+        assert.deepEqual(client.cache.getVersions(), {});
+        assert.deepEqual(client.cache.getIndex(), {});
+        assert.isNull(client.cache.get('/foo', {}));
+        assert.isNull(client.cache.get('/bar', {}));
+      });
+
+      it.only('invalidates a cached collection entry', () => {
+        client.onPush({ $cached: { foo: 2 } });
+
+        // Only the "bar" entry should be cached.
+        assert.deepEqual(
+          client.cache.getVersions(),
+          { foo: 2, bar: 2 },
+        );
+        assert.isNull(client.cache.get('/foo', {}));
+        assert.deepEqual(
+          client.cache.get('/bar', {}),
+          { $cached: true, $collection: 'bar', $data: 'barData' },
+        );
+      });
+    }); // describe: when caching is enabled
+  }); // describe: #onPush
+
   describe('#close', () => {
     let closeStub;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chai": "^4.3.7",
         "eslint": "^8.36.0",
         "jest": "^29.5.0",
+        "prettier": "^3.0.0",
         "sinon": "^15.0.1"
       },
       "engines": {
@@ -3737,6 +3738,21 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.5.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.5.0.tgz",
@@ -7224,6 +7240,12 @@
     },
     "prelude-ls": {
       "version": "1.2.1",
+      "dev": true
+    },
+    "prettier": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
+      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
       "dev": true
     },
     "pretty-format": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "chai": "^4.3.7",
     "eslint": "^8.36.0",
     "jest": "^29.5.0",
+    "prettier": "^3.0.0",
     "sinon": "^15.0.1"
   },
   "dependencies": {},


### PR DESCRIPTION
Adds the ability to trigger a cache flush from the TCP connection $push.

Also:
- Adds `prettier` package to devDependencies
- Update 'jest' test settings to auto-clear mocks
