### PR TITLE
FIx: Remove $flushCache handling

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -351,12 +351,6 @@ class Client extends EventEmitter {
       return;
     }
 
-    if (response.$flushCache) {
-      // Flush the entire cache.
-      this.cache.flush();
-      return;
-    }
-
     if (response.$cached) {
       // Invalidate a single entry in the cache.
       if (this.params.debug) {

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -813,16 +813,6 @@ describe('Client', () => {
         });
       });
 
-      it('flushes the cache', () => {
-        client.onPush({ $flushCache: true });
-
-        // Nothing should be cached.
-        expect(client.cache.getVersions()).toEqual({});
-        expect(client.cache.getIndex()).toEqual({});
-        expect(client.cache.get('/foo', {})).toBe(null);
-        expect(client.cache.get('/bar', {})).toBe(null);
-      });
-
       it('invalidates a cached collection entry', () => {
         client.onPush({ $cached: { foo: 2 } });
 


### PR DESCRIPTION
Remove client cache `$flushCache` mechanism as this has been replaced by `_global` versioning (server-side).