### PR TITLE
Fix: Remove client-side handling of admin.settings cache entry

### DIFF
--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -223,16 +223,6 @@ class Cache {
       ) {
         this.putVersion(collection, version);
         invalid[collection] = true;
-        // Hack to make admin.settings affect other api.settings
-        // TODO: figure out how to do this on the server side
-        if (collection === 'admin.settings') {
-          const versionCollections = Object.keys(this.versions);
-          for (const verCollection of versionCollections) {
-            if (String(verCollection).match(/\.settings$/)) {
-              invalid[verCollection] = true;
-            }
-          }
-        }
       }
     }
 


### PR DESCRIPTION
This client-side logic will be handled server-side.