### PR TITLE
Fix: handle promise rejection in auth stage

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -321,13 +321,12 @@ class Client extends EventEmitter {
 
           resolve(result);
         })
-        .then(() => {
-          this.flushRequestsPendingAuth();
-        })
         .catch((err) => {
           reject(err.message);
         });
       });
+    }).then(() => {
+      this.flushRequestsPendingAuth();
     });
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events');
 const crypto = require('crypto');
 
@@ -325,8 +327,9 @@ class Client extends EventEmitter {
           reject(err.message);
         });
       });
-    }).then(() => {
+    }).then((result) => {
       this.flushRequestsPendingAuth();
+      return result;
     });
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -277,10 +277,8 @@ class Client extends EventEmitter {
     }
 
     if (!this.authed) {
-      return new Promise((resolve) => {
-        // If not connected, do auth to get updated versions first
-        this.getPendingAuth(url, data, callback, resolve);
-      });
+      // If not connected, do auth to get updated versions first
+      return this.getPendingAuth(url, data, callback);
     }
 
     // Indicates whether to check the request cache or not
@@ -301,23 +299,35 @@ class Client extends EventEmitter {
     return this.request('get', url, data, callback);
   }
 
-  getPendingAuth(url, data, callback, resolve) {
-    if (this.requestsPendingAuth) {
-      this.requestsPendingAuth.push({ url, data, callback, resolve });
-      return;
-    }
+  getPendingAuth(url, data, callback) {
+    return new Promise((resolve, reject) => {
+      if (this.requestsPendingAuth) {
+        this.requestsPendingAuth.push({ url, data, callback, resolve });
+        return;
+      }
 
-    this.requestsPendingAuth = [];
+      this.requestsPendingAuth = [];
 
-    this.authWithKey(() => {
-      this.get(url, data, (_err, result, headers) => {
-        if (callback) {
-          callback(null, result, headers);
-        }
-        resolve(result);
+      this.authWithKey(() => {
+        this.get(url, data, (err, result, headers) => {
+          if (typeof callback === 'function') {
+            callback(err, result, headers);
+          }
+
+          if (err) {
+            reject(err);
+            return;
+          }
+
+          resolve(result);
+        })
+        .then(() => {
+          this.flushRequestsPendingAuth();
+        })
+        .catch((err) => {
+          reject(err.message);
+        });
       });
-
-      this.flushRequestsPendingAuth();
     });
   }
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -263,7 +263,7 @@ class Client extends EventEmitter {
    */
   get(url, data, callback) {
     if (!url) {
-      throw new Error('url is required');
+      return Promise.reject(new Error('url is required'));
     }
 
     if (typeof data === 'function') {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const EventEmitter = require('events');
 const tls = require('tls');
 const net = require('net');


### PR DESCRIPTION
https://github.com/swellstores/swell-node/pull/26

> Problem:
> If the API returns an error response during the auth stage, it results in a unhandled promise rejection error.

> Solution:
> This MR reworks the `getPendingAuth` method to forward the error response instead of just crashing the promise.

Fixed: return result after `flushRequestsPendingAuth` in `getPendingAuth` method.