### PR TITLE
fix: pass $req_id for auth and cached requests

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -16,10 +16,14 @@ class Client extends EventEmitter {
     super();
 
     this.params = {};
+    /** @type {Connection | null} */
     this.connection = null;
+    /** @type {Cache | null} */
     this.cache = null;
     this.authed = false;
     this.sentVersions = false;
+    /** @type {Array | null} */
+    this.requestsPendingAuth = null;
     this.env = null;
 
     if (clientId) {
@@ -72,6 +76,10 @@ class Client extends EventEmitter {
     return this;
   }
 
+  /**
+   * @param {(client: Client) => void} [callback]
+   * @returns {void}
+   */
   connect(callback) {
     this.connection = new Connection(
       this.params.host,
@@ -96,22 +104,22 @@ class Client extends EventEmitter {
       this.emit('close');
     });
     this.connection.on('error', (err) => {
-      if (EventEmitter.listenerCount(this, 'error')) {
+      if (this.listenerCount('error') > 0) {
         this.emit('error', 'Error: ' + err);
       }
     });
     this.connection.on('error.network', (err) => {
-      if (EventEmitter.listenerCount(this, 'error')) {
+      if (this.listenerCount('error') > 0) {
         this.emit('error', 'Network error: ' + err, 'network');
       }
     });
     this.connection.on('error.protocol', (err) => {
-      if (EventEmitter.listenerCount(this, 'error')) {
+      if (this.listenerCount('error') > 0) {
         this.emit('error', 'Protocol error: ' + err, 'protocol');
       }
     });
     this.connection.on('error.server', (err) => {
-      if (EventEmitter.listenerCount(this, 'error')) {
+      if (this.listenerCount('error') > 0) {
         this.emit('error', 'Server error: ' + err, 'server');
       }
     });
@@ -133,7 +141,7 @@ class Client extends EventEmitter {
 
     // Resolve data as promised
     const promises = this.promisifyData(data);
-    if (promises.length) {
+    if (promises.length > 0) {
       return Promise.all(promises).then(() => {
         this.request(method, url, data, callback);
       });
@@ -141,26 +149,26 @@ class Client extends EventEmitter {
 
     // Prepare url and data for request
     url = url && url.toString ? url.toString() : '';
-    data = {
+
+    const params = {
+      // Adding a unique request id to the request
+      $req_id: crypto.randomUUID(),
       $data: data !== undefined ? data : null,
     };
 
     if (!this.authed) {
       // Authenticates with key on first request
       // Get requests should use the get() method to initiate cache up front
-      data.$client = this.params.clientId;
-      data.$key = this.params.clientKey;
+      params.$client = this.params.clientId;
+      params.$key = this.params.clientKey;
 
       if (this.params.route) {
-        data.$route = this.params.route;
+        params.$route = this.params.route;
       }
       if (this.params.session) {
-        data.$session = this.params.session;
+        params.$session = this.params.session;
       }
     }
-
-    // Adding a unique request id to the request
-    data.$req_id = crypto.randomUUID();
 
     // Capture stacktrace
     const error = new Error();
@@ -181,15 +189,15 @@ class Client extends EventEmitter {
         }
       };
 
-      this.connection.request(method, url, data, (response) => {
+      this.connection.request(method, url, params, (response) => {
         if (response.$auth) {
           if (response.$end) {
             // Connection ended, retry auth
-            return this.request(method, url, data.$data, callback);
+            return this.request(method, url, params.$data, callback);
           } else {
             return this.auth(response.$auth, (response) => {
               this.flushRequestsPendingAuth();
-              return this.respond(method, url, data, response, responder);
+              return this.respond(method, url, params, response, responder);
             });
           }
         } else {
@@ -198,7 +206,7 @@ class Client extends EventEmitter {
             this.setAuthedEnv(response);
             this.sendCachedVersions();
           }
-          return this.respond(method, url, data, response, responder);
+          return this.respond(method, url, params, response, responder);
         }
       });
     });
@@ -216,19 +224,20 @@ class Client extends EventEmitter {
     }
 
     const promises = [];
-    if (typeof data === 'object') {
-      const keys = Object.keys(data);
-      for (const key of keys) {
-        if (data[key] && data[key].then) {
-          promises.push(data[key]);
-          thenResolvePromisedValue(data, key);
+    if (Array.isArray(data)) {
+      for (let i = 0; i < data.length; ++i) {
+        const value = data[i];
+
+        if (value && typeof value.then === 'function') {
+          promises.push(value);
+          thenResolvePromisedValue(data, i);
         }
       }
-    } else if (data instanceof Array) {
-      for (let i = 0; i < data.length; i++) {
-        if (data[i] && data[i].then) {
-          promises.push(data[i]);
-          thenResolvePromisedValue(data, i);
+    } else if (typeof data === 'object') {
+      for (const [key, value] of Object.entries(data)) {
+        if (value && typeof value.then === 'function') {
+          promises.push(value);
+          thenResolvePromisedValue(data, key);
         }
       }
     }
@@ -264,7 +273,7 @@ class Client extends EventEmitter {
    *
    * @param {string} url The URL
    * @param {Object?} data The request data
-   * @param {Function} callback The callback function
+   * @param {(err: any, data: any, response: any) => void} callback The callback function
    */
   get(url, data, callback) {
     if (!url) {
@@ -390,8 +399,11 @@ class Client extends EventEmitter {
     return this.request('delete', url, data, callback);
   }
 
-  // Note: Auth using `nonce` is mostly deprecated
-  // Prefer to use authWithKey instead
+  /**
+   * Auth using `nonce` is mostly deprecated
+   *
+   * @deprecated prefer to use `authWithKey` instead
+   */
   auth(nonce, callback) {
     const clientId = this.params.clientId;
     const clientKey = this.params.clientKey;
@@ -462,6 +474,7 @@ class Client extends EventEmitter {
     // Authenticate with client key initially
     // This is used to get $env before sending cached versions
     const creds = {
+      $req_id: crypto.randomUUID(),
       client: this.params.clientId,
       key: this.params.clientKey,
     };
@@ -495,7 +508,7 @@ class Client extends EventEmitter {
       if ($cached && Object.keys($cached).length > 0) {
         this.connection.request(
           'cached',
-          { $cached, $push: true },
+          { $req_id: crypto.randomUUID(), $cached, $push: true },
           (response) => {
             this.sentVersions = true;
             if (response && response.$cached) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,14 @@ const DEFAULT_PORT = 8443;
 const DEFAULT_VERIFY_CERT = true;
 const DEFAULT_VERSION = 1;
 
+function isPromise(obj) {
+  return Boolean(obj && typeof obj.then === 'function');
+}
+
+function generateRequestId() {
+  return crypto.randomUUID();
+}
+
 class Client extends EventEmitter {
   constructor(clientId, clientKey, options, callback) {
     super();
@@ -152,7 +160,7 @@ class Client extends EventEmitter {
 
     const params = {
       // Adding a unique request id to the request
-      $req_id: crypto.randomUUID(),
+      $req_id: generateRequestId(),
       $data: data !== undefined ? data : null,
     };
 
@@ -228,14 +236,14 @@ class Client extends EventEmitter {
       for (let i = 0; i < data.length; ++i) {
         const value = data[i];
 
-        if (value && typeof value.then === 'function') {
+        if (isPromise(value)) {
           promises.push(value);
           thenResolvePromisedValue(data, i);
         }
       }
     } else if (typeof data === 'object') {
       for (const [key, value] of Object.entries(data)) {
-        if (value && typeof value.then === 'function') {
+        if (isPromise(value)) {
           promises.push(value);
           thenResolvePromisedValue(data, key);
         }
@@ -474,7 +482,7 @@ class Client extends EventEmitter {
     // Authenticate with client key initially
     // This is used to get $env before sending cached versions
     const creds = {
-      $req_id: crypto.randomUUID(),
+      $req_id: generateRequestId(),
       client: this.params.clientId,
       key: this.params.clientKey,
     };
@@ -508,7 +516,7 @@ class Client extends EventEmitter {
       if ($cached && Object.keys($cached).length > 0) {
         this.connection.request(
           'cached',
-          { $req_id: crypto.randomUUID(), $cached, $push: true },
+          { $req_id: generateRequestId(), $cached, $push: true },
           (response) => {
             this.sentVersions = true;
             if (response && response.$cached) {

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -697,6 +697,7 @@ describe('Client', () => {
       expect(serverRequestStub).toHaveBeenCalledWith(
         'auth',
         {
+          $req_id: expect.any(String),
           $v: 1,
           client: 'id',
           key: 'key',
@@ -738,6 +739,7 @@ describe('Client', () => {
       expect(serverRequestStub).toHaveBeenCalledWith(
         'cached',
         {
+          $req_id: expect.any(String),
           $cached: { a: 1 },
           $push: true,
         },

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -4,23 +4,30 @@ const EventEmitter = require('events');
 const tls = require('tls');
 const net = require('net');
 
-const DEFAULT_NETWORK_ERROR = 'Server unexpectedly closed network connection.';
 const DEFAULT_TIMEOUT = 30000;
 const RETRY_TIME = 3000;
 const MAX_CONCURRENT = 10;
 
 class Connection extends EventEmitter {
+  /**
+   * @param {string} host
+   * @param {number | string} port
+   * @param {object} [options]
+   * @param {(connection: Connection) => void} [callback]
+   */
   constructor(host, port, options, callback) {
     super();
 
+    /** @type {tls.TLSSocket | null} */
     this.stream = null;
     this.connected = false;
     this.connectingTimeout = null;
     this.connectingRetryTimeout = null;
+    /** @type {string[]} */
     this.buffer = [];
     this.requestBuffer = [];
     this.requested = 0;
-    // Map <string, function> to register callbacks if responses can be received in any order
+    /** @type {Map<string, (response: any) => void>} to register callbacks if responses can be received in any order */
     this.requestCallbacks = new Map();
 
     this.host = host;
@@ -33,13 +40,17 @@ class Connection extends EventEmitter {
     }
     this.options = options;
 
-    this.maxConcurrent = options.maxConcurrent || MAX_CONCURRENT;
+    this.maxConcurrent = Number(options.maxConcurrent) || MAX_CONCURRENT;
 
     if (callback) {
       this.connect(callback);
     }
   }
 
+  /**
+   * @param {(connection: Connection) => void} callback
+   * @returns {void}
+   */
   connect(callback) {
     const proto = this.options.clear ? net : tls;
     const timeoutMs = this.options.timeout || DEFAULT_TIMEOUT;
@@ -89,13 +100,14 @@ class Connection extends EventEmitter {
     }
   }
 
-  request() {
-    // Copy args to avoid leaking
-    const args = new Array(arguments.length);
-    for (let i = 0; i < arguments.length; i++) {
-      args[i] = arguments[i];
-    }
-
+  /**
+   * @param {string} method
+   * @param {string} url
+   * @param {object} data
+   * @param {(response: any) => void} callback
+   * @returns {void}
+   */
+  request(...args) {
     this.requestBuffer.push(args);
 
     if (!this.connected || !this.stream) {
@@ -112,44 +124,61 @@ class Connection extends EventEmitter {
     if (this.requested > this.maxConcurrent) {
       return;
     }
+
     const args = this.requestBuffer[this.requested];
+
     if (args) {
-      const requestArr = args.slice(0, -1);
       // last argument is the callback
+      const requestArr = args.slice(0, -1);
       const req_id = requestArr[requestArr.length - 1]?.$req_id;
+      // Register callback in map, if $req_id is specified
       if (req_id) {
-        // Register callback in map, if $req_id is specified
-        this.requestCallbacks.set(req_id, args[args.length - 1]);
+        const callback = args[args.length - 1];
+        this.requestCallbacks.set(req_id, callback);
       }
+
       const request = JSON.stringify(requestArr);
       this.stream.write(request + '\n');
-      this.requested++;
+      this.requested += 1;
     }
   }
 
+  /**
+   * @param {tls.TLSSocket} stream 
+   * @param {string} buffer 
+   * @returns {void}
+   */
   receive(stream, buffer) {
     if (stream && this.stream !== stream) return;
 
     // Split buffer data on newline char
-    let j = 0;
-    for (let i = 0; i < buffer.length; i++) {
-      if (buffer[i] === '\n') {
-        this.buffer.push(buffer.slice(j, i));
+    const chunks = buffer.split('\n');
 
-        const data = this.buffer.join('');
+    // The last chunk of data may be incomplete
+    // The length of the last chunk will be 0 if the last character in the buffer is a newline
+    const lastChunk = chunks.pop();
 
-        this.buffer = [];
-        this.receiveResponse(data);
+    for (const chunk of chunks) {
+      let data = chunk;
 
-        j = i + 1;
+      if (this.buffer.length > 0) {
+        this.buffer.push(chunk);
+        data = this.buffer.join('');
+        this.buffer.length = 0;
       }
+
+      this.receiveResponse(data);
     }
 
-    if (j < buffer.length) {
-      this.buffer.push(buffer.slice(j, buffer.length));
+    if (lastChunk.length > 0) {
+      this.buffer.push(lastChunk);
     }
   }
 
+  /**
+   * @param {string} data
+   * @returns {void}
+   */
   receiveResponse(data) {
     let response;
 
@@ -179,7 +208,7 @@ class Connection extends EventEmitter {
       responder = request && request.pop();
     }
 
-    this.requested--;
+    this.requested -= 1;
 
     if (responder === undefined) {
       return;
@@ -211,11 +240,16 @@ class Connection extends EventEmitter {
     }
   }
 
+  /**
+   * @param {tls.TLSSocket} stream
+   * @param {Error} error
+   */
   error(stream, error) {
     const shouldReconnect =
       !this.connected &&
       this.requestBuffer.length > 0 &&
       !this.connectingRetryTimeout;
+
     if (shouldReconnect) {
       this.connectingRetryTimeout = setTimeout(() => {
         this.connectingRetryTimeout = null;
@@ -224,9 +258,14 @@ class Connection extends EventEmitter {
         }
       }, RETRY_TIME);
     }
+
     this.emit('error', error);
   }
 
+  /**
+   * @param {tls.TLSSocket} stream
+   * @returns {void}
+   */
   close(stream) {
     if (stream && this.stream !== stream) return;
 
@@ -249,36 +288,53 @@ class Connection extends EventEmitter {
     }
   }
 
-  // Handle timeout by closing if no requests are pending
+  /**
+   * Handle timeout by closing if no requests are pending
+   *
+   * @param {tls.TLSSocket} stream 
+   * @param {Error} error 
+   * @returns 
+   */
   timeout(stream, error) {
     if (stream && this.stream !== stream) return;
 
-    if (this.requestBuffer.length) {
+    if (this.requestBuffer.length > 0) {
       return;
     }
 
     this.close(stream);
   }
 
-  // FLush all requests when connected
+  /**
+   * FLush all requests when connected
+   */
   flushRequestBuffer() {
     if (!this.connected) {
       return;
     }
+
     const requestBuffer = this.requestBuffer;
     this.requestBuffer = [];
     this.requested = 0;
-    while (requestBuffer.length) {
-      this.request.apply(this, requestBuffer.shift());
+
+    for (const request of requestBuffer) {
+      this.request(...request);
     }
   }
 
-  // Flush all requests when a connection error occurs
+  /**
+   * Flush all requests when a connection error occurs
+   *
+   * @param {string} error 
+   * @returns {void}
+   */
   flushRequestBufferWithError(error) {
-    let hasRequests = this.requestBuffer.length;
-    while (--hasRequests >= 0) {
-      const request = this.requestBuffer.shift();
+    const requestBuffer = this.requestBuffer;
+    this.requestBuffer = [];
+
+    for (const request of requestBuffer) {
       const responder = request && request.pop();
+
       if (typeof responder === 'function') {
         responder({
           $status: 500,

--- a/lib/connection.test.js
+++ b/lib/connection.test.js
@@ -16,9 +16,24 @@ describe('Connection', () => {
       conn.receiveResponse = jest.fn();
 
       const response = JSON.stringify({ $push: true });
-      conn.receive(undefined, response);
-      conn.receive(undefined, '\n');
+      conn.receive(null, response);
+      conn.receive(null, '\n');
       expect(conn.receiveResponse).toHaveBeenCalledWith(response);
+    });
+
+    it('should call receiveResponse on newline character (multiple chunks in one buffer)', () => {
+      const conn = new Connection('host', 'port');
+      conn.receiveResponse = jest.fn();
+
+      const response1 = JSON.stringify({ value: 123 });
+      const response2 = JSON.stringify({ value: 456 });
+      const response3 = JSON.stringify({ value: 789 });
+
+      conn.receive(null, `${response1}\n${response2}\n${response3}\n`);
+
+      expect(conn.receiveResponse).toHaveBeenCalledWith(response1);
+      expect(conn.receiveResponse).toHaveBeenCalledWith(response2);
+      expect(conn.receiveResponse).toHaveBeenCalledWith(response3);
     });
   });
 


### PR DESCRIPTION
Now `$req_id` is passed with all types of requests, including `auth` and `cached`.
Fixed tests for auth and cached. They are now expected to receive $req_id.

Fixed `promisifyData` for array elements.

Replaced use of `listenerCount` function with modern usage.

Refactored the `Connection.receive` method for better performance. Removed cyclical search for newline character.
Added an additional test to make sure everything is ok.

Added type descriptions for many Connection methods.