### PR TITLE
fix: execute regular requests only after authorization

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -11,11 +11,14 @@ const DEFAULT_PORT = 8443;
 const DEFAULT_VERIFY_CERT = true;
 const DEFAULT_VERSION = 1;
 
-const MODULE_VERSION = `${
-  require('../package.json').name
-}@${
-  require('../package.json').version
-}`;
+const MODULE_VERSION = (({ name, version }) => {
+  return `${name}@${version}`;
+})(require('../package.json'));
+
+const USER_APP_VERSION =
+  process.env.npm_package_name && process.env.npm_package_version
+    ? `${process.env.npm_package_name}@${process.env.npm_package_version}`
+    : undefined;
 
 /**
  * @template T
@@ -199,6 +202,7 @@ class Client extends EventEmitter {
       // Adding a unique request id to the request
       $req_id: generateRequestId(),
       $user_agent: MODULE_VERSION,
+      $user_application: USER_APP_VERSION,
       $data: data !== undefined ? data : null,
     };
 
@@ -526,6 +530,7 @@ class Client extends EventEmitter {
     const creds = {
       $req_id: generateRequestId(),
       $user_agent: MODULE_VERSION,
+      $user_application: USER_APP_VERSION,
       client: this.params.clientId,
       key: this.params.clientKey,
     };
@@ -571,6 +576,7 @@ class Client extends EventEmitter {
           {
             $req_id: generateRequestId(),
             $user_agent: MODULE_VERSION,
+            $user_application: USER_APP_VERSION,
             $cached,
             $push: true,
           },

--- a/lib/client.js
+++ b/lib/client.js
@@ -11,6 +11,17 @@ const DEFAULT_PORT = 8443;
 const DEFAULT_VERIFY_CERT = true;
 const DEFAULT_VERSION = 1;
 
+const MODULE_VERSION = `${
+  require('../package.json').name
+}@${
+  require('../package.json').version
+}`;
+
+/**
+ * @template T
+ * @param {any} obj
+ * @returns {asserts obj is Promise<T>}
+ */
 function isPromise(obj) {
   return Boolean(obj && typeof obj.then === 'function');
 }
@@ -29,6 +40,11 @@ class Client extends EventEmitter {
     /** @type {Cache | null} */
     this.cache = null;
     this.authed = false;
+    /**
+     * Indicates whether an authorization request has been submitted
+     * but not yet completed
+     */
+    this.authRequested = false;
     this.sentVersions = false;
     /** @type {Array | null} */
     this.requestsPendingAuth = null;
@@ -89,6 +105,8 @@ class Client extends EventEmitter {
    * @returns {void}
    */
   connect(callback) {
+    this.authRequested = false;
+
     this.connection = new Connection(
       this.params.host,
       this.params.port,
@@ -99,38 +117,56 @@ class Client extends EventEmitter {
         onPush: this.onPush.bind(this),
       },
       () => {
-        callback && callback(this);
+        if (callback) {
+          callback(this);
+        }
+
         this.emit('connect', this);
       },
     );
-    this.connection.on('close', () => {
-      this.authed = false;
-      this.sentVersions = false;
-      if (this.cache) {
-        this.cache.reset();
-      }
-      this.emit('close');
-    });
-    this.connection.on('error', (err) => {
-      if (this.listenerCount('error') > 0) {
-        this.emit('error', 'Error: ' + err);
-      }
-    });
-    this.connection.on('error.network', (err) => {
-      if (this.listenerCount('error') > 0) {
-        this.emit('error', 'Network error: ' + err, 'network');
-      }
-    });
-    this.connection.on('error.protocol', (err) => {
-      if (this.listenerCount('error') > 0) {
-        this.emit('error', 'Protocol error: ' + err, 'protocol');
-      }
-    });
-    this.connection.on('error.server', (err) => {
-      if (this.listenerCount('error') > 0) {
-        this.emit('error', 'Server error: ' + err, 'server');
-      }
-    });
+
+    this.connection
+      .on('auth.require', () => {
+        if (this.authed) {
+          // When client is already authorized then release pending requests
+          this.connection.flushPendingBuffer();
+        } else if (this.authRequested) {
+          // When client has already requested authorization
+          // then send a request with authorization
+          this.connection.flushRequestBuffer();
+        } else {
+          // In other cases, create a request with authorization
+          this.authWithKey(() => {});
+        }
+      })
+      .on('close', () => {
+        this.authed = false;
+        this.sentVersions = false;
+        if (this.cache) {
+          this.cache.reset();
+        }
+        this.emit('close');
+      })
+      .on('error', (err) => {
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', 'Error: ' + err);
+        }
+      })
+      .on('error.network', (err) => {
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', 'Network error: ' + err, 'network');
+        }
+      })
+      .on('error.protocol', (err) => {
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', 'Protocol error: ' + err, 'protocol');
+        }
+      })
+      .on('error.server', (err) => {
+        if (this.listenerCount('error') > 0) {
+          this.emit('error', 'Server error: ' + err, 'server');
+        }
+      });
   }
 
   request(method, url, data, callback) {
@@ -161,6 +197,7 @@ class Client extends EventEmitter {
     const params = {
       // Adding a unique request id to the request
       $req_id: generateRequestId(),
+      $req_lib: MODULE_VERSION,
       $data: data !== undefined ? data : null,
     };
 
@@ -202,20 +239,21 @@ class Client extends EventEmitter {
           if (response.$end) {
             // Connection ended, retry auth
             return this.request(method, url, params.$data, callback);
-          } else {
-            return this.auth(response.$auth, (response) => {
-              this.flushRequestsPendingAuth();
-              return this.respond(method, url, params, response, responder);
-            });
           }
-        } else {
-          if (!this.authed) {
-            // Auth is handled by the first request in this case
-            this.setAuthedEnv(response);
-            this.sendCachedVersions();
-          }
-          return this.respond(method, url, params, response, responder);
+
+          return this.auth(response.$auth, (response) => {
+            this.flushRequestsPendingAuth();
+            return this.respond(method, url, params, response, responder);
+          });
         }
+
+        if (!this.authed) {
+          // Auth is handled by the first request in this case
+          this.setAuthedEnv(response);
+          this.sendCachedVersions(() => {});
+        }
+
+        return this.respond(method, url, params, response, responder);
       });
     });
   }
@@ -467,10 +505,13 @@ class Client extends EventEmitter {
       creds.$push = true;
     }
 
+    this.authRequested = true;
+
     return this.connection.request('auth', creds, (response) => {
       this.setAuthedEnv(response);
-      this.sendCachedVersions();
-      callback(response);
+      this.sendCachedVersions(() => {
+        callback(response);
+      });
     });
   }
 
@@ -483,6 +524,7 @@ class Client extends EventEmitter {
     // This is used to get $env before sending cached versions
     const creds = {
       $req_id: generateRequestId(),
+      $req_lib: MODULE_VERSION,
       client: this.params.clientId,
       key: this.params.clientKey,
     };
@@ -500,41 +542,64 @@ class Client extends EventEmitter {
       creds.$push = true;
     }
 
+    this.authRequested = true;
+
     return this.connection.request('auth', creds, (response) => {
       this.setAuthedEnv(response);
-      this.sendCachedVersions();
-      callback(response);
+      this.sendCachedVersions(() => {
+        callback(response);
+      });
     });
   }
 
-  sendCachedVersions() {
+  /**
+   * @param {() => void} callback
+   * @returns {void}
+   */
+  sendCachedVersions(callback) {
     if (!this.cache || !this.connection) {
-      return;
+      return callback();
     }
+
     if (!this.sentVersions) {
       const $cached = this.cache.getVersions();
+
       if ($cached && Object.keys($cached).length > 0) {
-        this.connection.request(
+        return this.connection.request(
           'cached',
-          { $req_id: generateRequestId(), $cached, $push: true },
+          {
+            $req_id: generateRequestId(),
+            $req_lib: MODULE_VERSION,
+            $cached,
+            $push: true,
+          },
           (response) => {
             this.sentVersions = true;
             if (response && response.$cached) {
               this.cache.clear(response);
             }
+            callback();
           },
         );
       } else {
         this.sentVersions = true;
       }
     }
+
+    return callback();
   }
 
   setAuthedEnv(response) {
     this.authed = true;
+    this.authRequested = false;
+
     if (this.cache && response) {
       this.env = response.$env;
       this.cache.setEnv(response.$env);
+    }
+
+    if (this.connection) {
+      this.connection.flushPendingBuffer();
     }
   }
 
@@ -543,6 +608,7 @@ class Client extends EventEmitter {
       this.connection.close();
       this.connection = null;
       this.authed = false;
+      this.authRequested = false;
       this.sentVersions = false;
     }
   }

--- a/lib/client.js
+++ b/lib/client.js
@@ -53,7 +53,8 @@ class Client extends EventEmitter {
     if (clientId) {
       this.init(clientId, clientKey, options);
     }
-    if (callback) {
+
+    if (typeof callback === 'function') {
       this.connect(callback);
     }
   }
@@ -117,7 +118,7 @@ class Client extends EventEmitter {
         onPush: this.onPush.bind(this),
       },
       () => {
-        if (callback) {
+        if (typeof callback === 'function') {
           callback(this);
         }
 
@@ -197,7 +198,7 @@ class Client extends EventEmitter {
     const params = {
       // Adding a unique request id to the request
       $req_id: generateRequestId(),
-      $req_lib: MODULE_VERSION,
+      $user_agent: MODULE_VERSION,
       $data: data !== undefined ? data : null,
     };
 
@@ -524,7 +525,7 @@ class Client extends EventEmitter {
     // This is used to get $env before sending cached versions
     const creds = {
       $req_id: generateRequestId(),
-      $req_lib: MODULE_VERSION,
+      $user_agent: MODULE_VERSION,
       client: this.params.clientId,
       key: this.params.clientKey,
     };
@@ -569,7 +570,7 @@ class Client extends EventEmitter {
           'cached',
           {
             $req_id: generateRequestId(),
-            $req_lib: MODULE_VERSION,
+            $user_agent: MODULE_VERSION,
             $cached,
             $push: true,
           },

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -231,7 +231,7 @@ describe('Client', () => {
         'url',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $data: 'data',
         },
         expect.any(Function),
@@ -251,7 +251,7 @@ describe('Client', () => {
         'url',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $client: 'id',
           $key: 'key',
           $data: 'data',
@@ -273,7 +273,7 @@ describe('Client', () => {
         'url',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $data: null,
         },
         expect.any(Function),
@@ -332,7 +332,7 @@ describe('Client', () => {
         'url',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $client: 'id',
           $key: 'key',
           $data: 'data',
@@ -714,7 +714,7 @@ describe('Client', () => {
         'auth',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $v: 1,
           client: 'id',
           key: 'key',
@@ -757,7 +757,7 @@ describe('Client', () => {
         'cached',
         {
           $req_id: expect.any(String),
-          $req_lib: expect.any(String),
+          $user_agent: expect.any(String),
           $cached: { a: 1 },
           $push: true,
         },

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -163,20 +163,21 @@ describe('Client', () => {
       const onSpy = jest.spyOn(Connection.prototype, 'on');
       client.connect();
 
-      expect(onSpy).toHaveBeenNthCalledWith(1, 'close', expect.any(Function));
-      expect(onSpy).toHaveBeenNthCalledWith(2, 'error', expect.any(Function));
+      expect(onSpy).toHaveBeenNthCalledWith(1, 'auth.require', expect.any(Function));
+      expect(onSpy).toHaveBeenNthCalledWith(2, 'close', expect.any(Function));
+      expect(onSpy).toHaveBeenNthCalledWith(3, 'error', expect.any(Function));
       expect(onSpy).toHaveBeenNthCalledWith(
-        3,
+        4,
         'error.network',
         expect.any(Function),
       );
       expect(onSpy).toHaveBeenNthCalledWith(
-        4,
+        5,
         'error.protocol',
         expect.any(Function),
       );
       expect(onSpy).toHaveBeenNthCalledWith(
-        5,
+        6,
         'error.server',
         expect.any(Function),
       );
@@ -228,7 +229,11 @@ describe('Client', () => {
       expect(serverRequestStub).toHaveBeenCalledWith(
         'get',
         'url',
-        { $data: 'data', $req_id: expect.any(String) },
+        {
+          $req_id: expect.any(String),
+          $req_lib: expect.any(String),
+          $data: 'data',
+        },
         expect.any(Function),
       );
     });
@@ -245,6 +250,8 @@ describe('Client', () => {
         'get',
         'url',
         {
+          $req_id: expect.any(String),
+          $req_lib: expect.any(String),
           $client: 'id',
           $key: 'key',
           $data: 'data',
@@ -252,7 +259,6 @@ describe('Client', () => {
             client: 'id2',
           },
           $session: 'session-id',
-          $req_id: expect.any(String),
         },
         expect.any(Function),
       );
@@ -265,7 +271,11 @@ describe('Client', () => {
       expect(serverRequestStub).toHaveBeenCalledWith(
         'get',
         'url',
-        { $data: null, $req_id: expect.any(String) },
+        {
+          $req_id: expect.any(String),
+          $req_lib: expect.any(String),
+          $data: null,
+        },
         expect.any(Function),
       );
     });
@@ -320,7 +330,13 @@ describe('Client', () => {
       expect(respondSpy).toHaveBeenCalledWith(
         'get',
         'url',
-        { $client: 'id', $data: 'data', $key: 'key', $req_id: expect.any(String) },
+        {
+          $req_id: expect.any(String),
+          $req_lib: expect.any(String),
+          $client: 'id',
+          $key: 'key',
+          $data: 'data',
+        },
         { $status: 200, $data: 'success' },
         expect.any(Function),
       );
@@ -698,6 +714,7 @@ describe('Client', () => {
         'auth',
         {
           $req_id: expect.any(String),
+          $req_lib: expect.any(String),
           $v: 1,
           client: 'id',
           key: 'key',
@@ -732,7 +749,7 @@ describe('Client', () => {
     });
 
     it('send cached versions to server auth with credentials', () => {
-      client.sendCachedVersions();
+      client.sendCachedVersions(() => {});
 
       expect(getCacheStub).toHaveBeenCalledTimes(1);
       expect(serverRequestStub).toHaveBeenCalledTimes(1);
@@ -740,6 +757,7 @@ describe('Client', () => {
         'cached',
         {
           $req_id: expect.any(String),
+          $req_lib: expect.any(String),
           $cached: { a: 1 },
           $push: true,
         },
@@ -752,10 +770,13 @@ describe('Client', () => {
 
   describe('#setAuthedEnv', () => {
     let client;
+    let flushPendingBufferStub;
 
     beforeEach(() => {
+      flushPendingBufferStub = jest.fn();
       client = new Client('id', 'key', { cache: true });
       client.cache = new Cache('id');
+      client.connection = { flushPendingBuffer: flushPendingBufferStub };
     });
 
     it('sets authed and env flags', () => {
@@ -764,6 +785,8 @@ describe('Client', () => {
       expect(client.authed).toBe(true);
       expect(client.env).toEqual('test');
       expect(client.cache.env).toEqual('test');
+      // make sure that pending requests will be sent for execution after authorization
+      expect(flushPendingBufferStub).toHaveBeenCalled();
     });
 
     it('sets authed and env flags', () => {
@@ -772,6 +795,8 @@ describe('Client', () => {
       expect(client.authed).toBe(true);
       expect(client.env).toBe(undefined);
       expect(client.cache.env).toBe(undefined);
+      // make sure that pending requests will be sent for execution after authorization
+      expect(flushPendingBufferStub).toHaveBeenCalled();
     });
   });
 

--- a/lib/client.test.js
+++ b/lib/client.test.js
@@ -232,6 +232,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $data: 'data',
         },
         expect.any(Function),
@@ -252,6 +253,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $client: 'id',
           $key: 'key',
           $data: 'data',
@@ -274,6 +276,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $data: null,
         },
         expect.any(Function),
@@ -333,6 +336,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $client: 'id',
           $key: 'key',
           $data: 'data',
@@ -715,6 +719,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $v: 1,
           client: 'id',
           key: 'key',
@@ -758,6 +763,7 @@ describe('Client', () => {
         {
           $req_id: expect.any(String),
           $user_agent: expect.any(String),
+          $user_application: expect.any(String),
           $cached: { a: 1 },
           $push: true,
         },

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -8,6 +8,26 @@ const DEFAULT_TIMEOUT = 30000;
 const RETRY_TIME = 3000;
 const MAX_CONCURRENT = 10;
 
+/**
+ * @template T
+ * @param {Array<T>} array
+ * @returns {T | undefined}
+ */
+function getLastElement(array) {
+  return Array.isArray(array)
+    ? array[array.length - 1]
+    : undefined;
+}
+
+/**
+ * @param {any[]} request
+ * @returns {boolean}
+ */
+function hasRequestAuthData(request) {
+  const data = request[request.length - 2];
+  return data.$client && data.$key;
+}
+
 class Connection extends EventEmitter {
   /**
    * @param {string} host
@@ -20,12 +40,20 @@ class Connection extends EventEmitter {
 
     /** @type {tls.TLSSocket | null} */
     this.stream = null;
+    /**
+     * if the connection is not ready
+     * then it can only perform service requests such as `auth` or `cached`
+     */
+    this.ready = false;
     this.connected = false;
     this.connectingTimeout = null;
     this.connectingRetryTimeout = null;
     /** @type {string[]} */
     this.buffer = [];
+    // TODO: replace the array with a queue data structure
     this.requestBuffer = [];
+    /** Pending requests will be sent for execution after authorization */
+    this.pendingBuffer = [];
     this.requested = 0;
     /** @type {Map<string, (response: any) => void>} to register callbacks if responses can be received in any order */
     this.requestCallbacks = new Map();
@@ -48,12 +76,14 @@ class Connection extends EventEmitter {
   }
 
   /**
-   * @param {(connection: Connection) => void} callback
+   * @param {(connection: Connection) => void} [callback]
    * @returns {void}
    */
   connect(callback) {
     const proto = this.options.clear ? net : tls;
     const timeoutMs = this.options.timeout || DEFAULT_TIMEOUT;
+
+    this.ready = false;
 
     this.stream = proto.connect(
       {
@@ -63,22 +93,34 @@ class Connection extends EventEmitter {
       },
       () => {
         this.connected = true;
+
         clearTimeout(this.connectingTimeout);
         this.connectingTimeout = null;
-        this.flushRequestBuffer();
-        callback && callback(this);
+
+        if (callback) {
+          callback(this);
+        }
+
         this.emit('connect');
+
+        if (this.isBufferNotEmpty()) {
+          // Ask the client to create an authorization request
+          this.emit('auth.require');
+        }
       },
     );
-    this.stream.on('error', this.error.bind(this, this.stream));
-    this.stream.on('data', this.receive.bind(this, this.stream));
-    this.stream.on('close', this.close.bind(this, this.stream));
-    this.stream.on('timeout', this.timeout.bind(this, this.stream));
-    this.stream.setEncoding('utf8');
+
+    this.stream
+      .setEncoding('utf8')
+      .on('error', this.error.bind(this, this.stream))
+      .on('data', this.receive.bind(this, this.stream))
+      .on('close', this.close.bind(this, this.stream))
+      .on('timeout', this.timeout.bind(this, this.stream));
 
     // Retry periodically just in case
     this.connectingRetryTimeout = setTimeout(() => {
-      const shouldReconnect = !this.connected && this.requestBuffer.length > 0;
+      const shouldReconnect = !this.connected && this.isBufferNotEmpty();
+
       if (shouldReconnect) {
         this.connectingRetryTimeout = null;
         this.connect();
@@ -108,12 +150,32 @@ class Connection extends EventEmitter {
    * @returns {void}
    */
   request(...args) {
-    this.requestBuffer.push(args);
+    switch (args[0]) {
+      case 'auth':
+      case 'cached':
+        // Service requests are always added to the execution queue
+        this.requestBuffer.push(args);
+        break;
 
-    if (!this.connected || !this.stream) {
-      if (!this.stream) {
-        this.connect();
+      default: {
+        // Until the connection is ready
+        // all regular requests are added to the waiting queue
+        // until authorization is completed
+        const list = this.ready || hasRequestAuthData(args)
+          ? this.requestBuffer
+          : this.pendingBuffer;
+
+        list.push(args);
+        break;
       }
+    }
+
+    if (!this.connected) {
+      return;
+    }
+
+    if (!this.stream) {
+      this.connect();
       return;
     }
 
@@ -125,7 +187,10 @@ class Connection extends EventEmitter {
       return;
     }
 
-    const args = this.requestBuffer[this.requested];
+    // Check array length to avoid creating holes
+    const args = this.requestBuffer.length > this.requested
+      ? this.requestBuffer[this.requested]
+      : undefined;
 
     if (args) {
       // last argument is the callback
@@ -205,7 +270,7 @@ class Connection extends EventEmitter {
       this.requestCallbacks.delete(req_id);
     } else {
       // Otherwise use callback from last argument of request
-      responder = request && request.pop();
+      responder = getLastElement(request);
     }
 
     this.requested -= 1;
@@ -247,7 +312,7 @@ class Connection extends EventEmitter {
   error(stream, error) {
     const shouldReconnect =
       !this.connected &&
-      this.requestBuffer.length > 0 &&
+      this.isBufferNotEmpty() &&
       !this.connectingRetryTimeout;
 
     if (shouldReconnect) {
@@ -279,11 +344,23 @@ class Connection extends EventEmitter {
       this.stream.end();
     }
 
+    this.ready = false;
     this.connected = false;
     this.stream = null;
     this.requestCallbacks.clear();
 
-    if (this.requestBuffer.length > 0) {
+    this.pendingBuffer.unshift(
+      ...this.requestBuffer.filter((request) =>
+        Array.isArray(request) &&
+          request[0] !== 'auth' &&
+          request[0] !== 'cached'
+      ),
+    );
+
+    this.requestBuffer = [];
+    this.requested = 0;
+
+    if (this.isBufferNotEmpty()) {
       this.connect();
     }
   }
@@ -298,7 +375,7 @@ class Connection extends EventEmitter {
   timeout(stream, error) {
     if (stream && this.stream !== stream) return;
 
-    if (this.requestBuffer.length > 0) {
+    if (this.isBufferNotEmpty()) {
       return;
     }
 
@@ -306,7 +383,7 @@ class Connection extends EventEmitter {
   }
 
   /**
-   * FLush all requests when connected
+   * Flush all requests upon connection
    */
   flushRequestBuffer() {
     if (!this.connected) {
@@ -323,17 +400,36 @@ class Connection extends EventEmitter {
   }
 
   /**
+   * Flush pending requests upon connection and authorization
+   */
+  flushPendingBuffer() {
+    if (!this.connected) {
+      return;
+    }
+
+    const requestBuffer = this.pendingBuffer;
+    this.pendingBuffer = [];
+    this.ready = true;
+
+    for (const request of requestBuffer) {
+      this.request(...request);
+    }
+  }
+
+  /**
    * Flush all requests when a connection error occurs
    *
    * @param {string} error 
    * @returns {void}
    */
   flushRequestBufferWithError(error) {
-    const requestBuffer = this.requestBuffer;
+    const requestBuffer = this.requestBuffer.concat(this.pendingBuffer);
     this.requestBuffer = [];
+    this.pendingBuffer = [];
+    this.requested = 0;
 
     for (const request of requestBuffer) {
-      const responder = request && request.pop();
+      const responder = getLastElement(request);
 
       if (typeof responder === 'function') {
         responder({
@@ -342,6 +438,10 @@ class Connection extends EventEmitter {
         });
       }
     }
+  }
+
+  isBufferNotEmpty() {
+    return this.requestBuffer.length > 0 || this.pendingBuffer.length > 0;
   }
 }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -28,6 +28,33 @@ function hasRequestAuthData(request) {
   return data.$client && data.$key;
 }
 
+/**
+ * Connection workflow
+ *
+ * When a Connection is created, an attempt will be made to connect to the server immediately.
+ * If a callback was passed.
+ *
+ * If the connection attempt fails, several retries will occur, after which an error will be thrown.
+ * All requests will be rejected with this error.
+ *
+ * While the connection has not yet been established, the client can still send requests.
+ * Such requests are added to the pending buffer.
+ * This applies to all requests except service requests, such as `auth` and `cached`.
+ * These requests are always added to the active buffer and will be executed immediately after the connection is established.
+ *
+ * The first request to the server should be authorization, where credentials are transmitted in the body of the request.
+ * Until authorization is completed, no other requests will be sent. All requests will be added to the pending buffer.
+ *
+ * Once authorization is complete, all requests in the pending buffer will be moved to the active buffer.
+ * __From this moment on, the connection is considered ready.__
+ * Requests will be sent to the server according to the concurrency settings.
+ *
+ * When the connection unexpectedly breaks down and there are pending requests in the active buffer,
+ * all those requests will be moved to the pending buffer.
+ * After the connection is broken, we need to re-establish the connection and go through authorization again.
+ * No other requests should be submitted until re-authorization is completed.
+ * All requests that were not completed will be sent again as soon as the connection is ready again.
+ */
 class Connection extends EventEmitter {
   /**
    * @param {string} host
@@ -70,7 +97,7 @@ class Connection extends EventEmitter {
 
     this.maxConcurrent = Number(options.maxConcurrent) || MAX_CONCURRENT;
 
-    if (callback) {
+    if (typeof callback === 'function') {
       this.connect(callback);
     }
   }
@@ -97,7 +124,7 @@ class Connection extends EventEmitter {
         clearTimeout(this.connectingTimeout);
         this.connectingTimeout = null;
 
-        if (callback) {
+        if (typeof callback === 'function') {
           callback(this);
         }
 

--- a/lib/connection.test.js
+++ b/lib/connection.test.js
@@ -59,14 +59,73 @@ describe('Connection', () => {
     });
 
     it('should not error when onPush is not defined', () => {
-      const onPush = jest.fn();
       const conn = new Connection('host', 'port');
       const response = { $push: true };
       conn.receiveResponse(JSON.stringify(response));
     });
 
-    it('should resolve requests in any ordrer, if $req_id is defined', () => {
+    it('should buffer regular requests until the connection is ready', () => {
       const conn = new Connection('host', 'port');
+      conn.connected = true;
+      conn.stream = {
+        write: () => {},
+      };
+
+      // initially the connection is not ready
+      expect(conn.ready).toBe(false);
+
+      const callbackSpy = jest.fn();
+
+      // send a regular request
+      conn.request('get', '/products', {}, callbackSpy);
+
+      // make sure the request is in the pending buffer
+      expect(conn.requestBuffer.length).toBe(0);
+      expect(conn.pendingBuffer.length).toBe(1);
+
+      // send `auth` and `cached` service requests
+      conn.request('auth', callbackSpy);
+      conn.request('cached', callbackSpy);
+
+      // make sure that service requests have been written to the active buffer
+      expect(conn.requestBuffer.length).toBe(2);
+      expect(conn.pendingBuffer.length).toBe(1);
+
+      // send a regular request including authorization information
+      conn.request(
+        'get',
+        '/products',
+        { $client: 'test', $key: 'test_key' },
+        callbackSpy
+      );
+
+      // make sure that such a request will be added to the active buffer
+      expect(conn.requestBuffer.length).toBe(3);
+      expect(conn.pendingBuffer.length).toBe(1);
+
+      // simulate the execution of auth and cached requests
+      conn.requestBuffer.length = 0;
+
+      // called after authorization
+      conn.flushPendingBuffer();
+
+      // now the connection is ready
+      expect(conn.ready).toBe(true);
+      expect(conn.requestBuffer.length).toBe(1);
+      expect(conn.pendingBuffer.length).toBe(0);
+
+      // make sure that all requests are now added to the active buffer
+      conn.request('get', '/products', {}, callbackSpy);
+      conn.request('cached', callbackSpy);
+      conn.request('auth', callbackSpy);
+
+      expect(conn.requestBuffer.length).toBe(4);
+      expect(conn.pendingBuffer.length).toBe(0);
+    });
+
+    it('should resolve requests in any order, if $req_id is defined', () => {
+      const conn = new Connection('host', 'port');
+      conn.ready = true;
       conn.connected = true;
       conn.stream = {
         write: () => {},


### PR DESCRIPTION
Fixed a bug where requests were sent before authorization was completed.

Added swell-node version to request data.

Check array length to avoid creating holes.

When the connection is broken or closed, all active requests are moved to pending. This is necessary so that when reconnecting, the authorization request is executed first, and then all other requests.

test: should buffer regular requests until the connection is ready
test: send pending execution requests after authorization